### PR TITLE
Feature #103 recursive explain and search ux

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ chmod +x /usr/local/bin/kubectl-apidocs
 kubectl apidocs
 ```
 
+Tree search and details search are context-aware:
+
+- Press `/` while the tree has focus to search within the currently visible tree root.
+- Press `TAB` to move to the details pane, then `/` to search within the current details text.
+- Press `r` on a resource to show recursive explain output in the details pane.
+
 ---
 
 ## Terminal Navigation Guide
@@ -104,8 +110,10 @@ kubectl apidocs
 | **`<ARROWS>`** | Navigate (Arrow keys)                                                |
 | **`<ENTER>`**  | Select (group/resource)                                              |
 | **`<TAB>`**    | Switch focus between tree/details (NOTE: details-view is scrollable) |
-| **`<ESC>`**    | Step back in navigation                                              |
-| **`/`**        | Open search mode                                                     |
+| **`<ESC>`**    | Step back in tree navigation or clear details search                 |
+| **`/`**        | Search current tree scope or current details text                    |
+| **`<r>`**      | Show recursive explain output for the selected resource              |
+| **`<n/N>`**    | Jump to next/previous match in details search                        |
 | **`<:cmd>`**   | Execute a command                                                    |
 | **`<ctrl-c>`** | Quit application                                                     |
 | **`<b>`**      | Step back to closest root                                            |
@@ -116,6 +124,9 @@ kubectl apidocs
 
 - **Use `hjkl` for fast movement** (Vim-style navigation).
 - **`TAB` lets you quickly switch between tree-view and details (NOTE: details-view is scrollable)**.
+- **Tree search is scoped to the current tree root**, so searching inside a selected resource stays within that resource.
+- **Use `r` before switching to the details pane** if you want to search inside full recursive explain output.
+- **In the details pane, use `/` then `n` / `N`** to search and move through matches.
 
 ---
 

--- a/internal/apidocs/explainer.go
+++ b/internal/apidocs/explainer.go
@@ -23,21 +23,34 @@ func NewExplainer(gvr schema.GroupVersionResource, openAPIClient openapiclient.C
 }
 
 func (e *Explainer) Explain(w io.Writer, path string) error {
+	return e.explain(w, path, false)
+}
+
+func (e *Explainer) ExplainRecursive(w io.Writer, path string) error {
+	return e.explain(w, path, true)
+}
+
+func (e *Explainer) explain(w io.Writer, path string, recursive bool) error {
 	if path == "" {
 		return fmt.Errorf("empty path is not allowed for explain: %s", path)
 	}
-	fields := strings.Split(path, ".")
-	if len(fields) > 0 {
-		// Skip resource name
-		fields = fields[1:]
-	}
+	fields := explainFields(path)
 
 	return explainv2.PrintModelDescription(
 		fields,
 		w,
 		e.openAPIClient,
 		e.gvr,
-		false,
+		recursive,
 		"plaintext",
 	)
+}
+
+func explainFields(path string) []string {
+	fields := strings.Split(path, ".")
+	if len(fields) > 0 {
+		// Skip resource name
+		fields = fields[1:]
+	}
+	return fields
 }

--- a/internal/apidocs/explainer_test.go
+++ b/internal/apidocs/explainer_test.go
@@ -1,0 +1,33 @@
+package apidocs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExplainFields_ResourcePath(t *testing.T) {
+	got := explainFields("Binding.metadata.name")
+	want := []string{"metadata", "name"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestExplainFields_ResourceOnly(t *testing.T) {
+	got := explainFields("Binding")
+
+	if len(got) != 0 {
+		t.Fatalf("expected no fields, got %v", got)
+	}
+}
+
+func TestExplainCacheKey(t *testing.T) {
+	if got := explainCacheKey("Binding", false); got != "Binding" {
+		t.Fatalf("expected Binding, got %q", got)
+	}
+
+	if got := explainCacheKey("Binding", true); got != "Binding#recursive" {
+		t.Fatalf("expected Binding#recursive, got %q", got)
+	}
+}

--- a/internal/apidocs/ui.go
+++ b/internal/apidocs/ui.go
@@ -31,6 +31,7 @@ type cmdInputPurpose string
 var (
 	cmdInputPurposeCmd    cmdInputPurpose = "cmd"
 	cmdInputPurposeSearch cmdInputPurpose = "search"
+	cmdInputPurposeFind   cmdInputPurpose = "find"
 )
 
 type UIState struct {
@@ -46,6 +47,16 @@ type UIState struct {
 	treeLinks               *TreeLinks
 	explainCache            *sync.Map
 	isInFilter              bool // whether current resources view filtered by search CMD
+	detailsRawText          string
+	detailsSearchTerm       string
+	detailsSearchMatches    []detailsMatch
+	detailsSearchIndex      int
+}
+
+type detailsMatch struct {
+	start    int
+	end      int
+	regionID string
 }
 
 func RunApp(uiData *UIData) error {
@@ -90,6 +101,7 @@ func RunApp(uiData *UIData) error {
 	// Create a main details view (rhs)
 	apiResourcesDetailsView := tview.NewTextView()
 	apiResourcesDetailsView.SetDynamicColors(true)
+	apiResourcesDetailsView.SetRegions(true)
 	apiResourcesDetailsView.SetBorder(true)
 	apiResourcesDetailsView.SetTitle("Details")
 	apiResourcesDetailsView.SetScrollable(true)
@@ -276,7 +288,7 @@ func populateNodeWithResourceFields(
 
 func getHelpMenuContent() string {
 	return strings.TrimSpace(`
-[yellow]</term>[-]  Search | [yellow]<:cmd>[-] Command            | [yellow]<ENTER>[-] Select (gr/res) | [yellow]<hjkl>[-]   Navigate |
-[yellow]<ctrl-c>[-] Quit   | [yellow]<TAB>[-]  Focus tree/details | [yellow]<ESC>[-]   Step back       | [yellow]<ARROWS>[-] Navigate |
+[yellow]</term>[-]  Search             | [yellow]<:cmd>[-] Command            | [yellow]<ENTER>[-] Select (gr/res)   | [yellow]<hjkl>[-] Navigate  | [yellow]<r>[-]   Recursive |
+[yellow]<ctrl-c>[-] Quit               | [yellow]<TAB>[-]  Focus tree/details | [yellow]<ESC>[-]   Step back/clear   | [yellow]<n/N>[-]  Next/prev
 `)
 }

--- a/internal/apidocs/uievents.go
+++ b/internal/apidocs/uievents.go
@@ -4,9 +4,16 @@ import (
 	"bytes"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+)
+
+const (
+	detailsSearchMatchStyle        = "[black:teal]"
+	detailsSearchCurrentMatchStyle = "[black:yellow]"
+	detailsSearchResetStyle        = "[-:-:-]"
 )
 
 func setupListeners(
@@ -91,6 +98,22 @@ func setupListenersForResourcesTreeView(uiData *UIData, uiState *UIState) error 
 			return nil
 		}
 
+		if event.Key() == tcell.KeyRune && event.Rune() == 'r' {
+			currentNode := uiState.apiResourcesTreeView.GetCurrentNode()
+			if currentNode == nil {
+				return nil
+			}
+			data, err := extractTreeData(currentNode)
+			if err != nil {
+				listenersErr = err
+				return nil
+			}
+			if data.IsNodeType(nodeTypeResource) {
+				explainPathRecursive(uiState, data, uiData)
+				return nil
+			}
+		}
+
 		// h/l -> collapse/expand
 		// left-arrow/right-arrow -> collapse/expand
 		// NOTE: expand fields only, ignore groups and resources (they're managed by ENTER)
@@ -157,7 +180,7 @@ func setupListenersForResourcesTreeView(uiData *UIData, uiState *UIState) error 
 			listenersErr = err
 			return
 		}
-		uiState.apiResourcesDetailsView.SetText(data.path)
+		setDetailsText(uiState, data.path)
 		if data.IsNodeType(nodeTypeField, nodeTypeResource) {
 			explainPath(uiState, data, uiData)
 		}
@@ -169,19 +192,45 @@ func setupListenersForResourcesTreeView(uiData *UIData, uiState *UIState) error 
 }
 
 func explainPath(uiState *UIState, data *TreeData, uiData *UIData) {
-	if cached, ok := uiState.explainCache.Load(data.path); ok {
-		slog.Debug("explain", slog.String("cached", data.path))
-		uiState.apiResourcesDetailsView.SetText(fmt.Sprintf("%s\n\n%s", data.path, cached))
+	cacheKey := explainCacheKey(data.path, false)
+	if cached, ok := uiState.explainCache.Load(cacheKey); ok {
+		slog.Debug("explain", slog.String("cached", cacheKey))
+		setDetailsText(uiState, fmt.Sprintf("%s\n\n%s", data.path, cached))
 	} else {
-		slog.Debug("explain", slog.String("perform", data.path))
+		slog.Debug("explain", slog.String("perform", cacheKey))
 		explainer := NewExplainer(*data.gvr, uiData.OpenAPIClient)
 		buf := bytes.Buffer{}
 		err := explainer.Explain(&buf, data.path)
 		if err == nil {
-			uiState.apiResourcesDetailsView.SetText(fmt.Sprintf("%s\n\n%s", data.path, buf.String()))
-			uiState.explainCache.Store(data.path, buf.String())
+			setDetailsText(uiState, fmt.Sprintf("%s\n\n%s", data.path, buf.String()))
+			uiState.explainCache.Store(cacheKey, buf.String())
 		}
 	}
+}
+
+func explainPathRecursive(uiState *UIState, data *TreeData, uiData *UIData) {
+	cacheKey := explainCacheKey(data.path, true)
+	if cached, ok := uiState.explainCache.Load(cacheKey); ok {
+		slog.Debug("explain", slog.String("cached", cacheKey))
+		setDetailsText(uiState, fmt.Sprintf("%s [recursive]\n\n%s", data.path, cached))
+		return
+	}
+
+	slog.Debug("explain", slog.String("perform", cacheKey))
+	explainer := NewExplainer(*data.gvr, uiData.OpenAPIClient)
+	buf := bytes.Buffer{}
+	err := explainer.ExplainRecursive(&buf, data.path)
+	if err == nil {
+		setDetailsText(uiState, fmt.Sprintf("%s [recursive]\n\n%s", data.path, buf.String()))
+		uiState.explainCache.Store(cacheKey, buf.String())
+	}
+}
+
+func explainCacheKey(path string, recursive bool) string {
+	if recursive {
+		return path + "#recursive"
+	}
+	return path
 }
 
 func expandCollapseHJKL(uiState *UIState, expanded bool) error {
@@ -208,6 +257,30 @@ func expandCollapseHJKL(uiState *UIState, expanded bool) error {
 
 func setupListenersForResourceDetailsView(uiState *UIState) error {
 	uiState.apiResourcesDetailsView.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if event.Key() == tcell.KeyRune && event.Rune() == '/' {
+			if uiState.cmdInputIsOn {
+				return nil
+			}
+			uiState.cmdInput.SetLabel("Find:")
+			uiState.cmdInput.SetText(uiState.detailsSearchTerm)
+			uiState.cmdInputIsOn = true
+			uiState.cmdInputPurpose = cmdInputPurposeFind
+			uiState.mainLayout.AddItem(uiState.cmdInput, 3, 1, true)
+			setFocusOn(uiState, uiState.cmdInput)
+			return nil
+		}
+		if event.Key() == tcell.KeyRune && event.Rune() == 'n' {
+			selectNextDetailsMatch(uiState)
+			return nil
+		}
+		if event.Key() == tcell.KeyRune && event.Rune() == 'N' {
+			selectPreviousDetailsMatch(uiState)
+			return nil
+		}
+		if event.Key() == tcell.KeyEscape {
+			clearDetailsSearch(uiState)
+			return nil
+		}
 		if event.Key() == tcell.KeyTab {
 			setFocusOn(uiState, uiState.apiResourcesTreeView) // Switch focus to the TreeView
 			return nil
@@ -228,6 +301,10 @@ func setupListenersForCmdInput(uiState *UIState) error {
 				showFilteredTree(uiState, uiState.apiResourcesTreeView, searchTerm)
 			}
 
+			if uiState.cmdInputIsOn && uiState.cmdInputPurpose == cmdInputPurposeFind {
+				applyDetailsSearch(uiState, uiState.cmdInput.GetText())
+			}
+
 			// quit
 			if uiState.cmdInputIsOn && uiState.cmdInputPurpose == cmdInputPurposeCmd {
 				cmd := uiState.cmdInput.GetText()
@@ -239,7 +316,11 @@ func setupListenersForCmdInput(uiState *UIState) error {
 			uiState.cmdInput.SetText("")
 			uiState.cmdInputIsOn = false
 			uiState.mainLayout.RemoveItem(uiState.cmdInput)   // Hide the input field
-			setFocusOn(uiState, uiState.apiResourcesTreeView) // Focus back to main layout
+			if uiState.cmdInputPurpose == cmdInputPurposeFind {
+				setFocusOn(uiState, uiState.apiResourcesDetailsView)
+			} else {
+				setFocusOn(uiState, uiState.apiResourcesTreeView) // Focus back to main layout
+			}
 		}
 
 		// handle ESC: hide cmd-input on ESC
@@ -247,12 +328,138 @@ func setupListenersForCmdInput(uiState *UIState) error {
 			if uiState.cmdInputIsOn {
 				uiState.cmdInputIsOn = false
 				uiState.mainLayout.RemoveItem(uiState.cmdInput)   // Hide the input field
-				setFocusOn(uiState, uiState.apiResourcesTreeView) // Focus back to main layout
+				if uiState.cmdInputPurpose == cmdInputPurposeFind {
+					setFocusOn(uiState, uiState.apiResourcesDetailsView)
+				} else {
+					setFocusOn(uiState, uiState.apiResourcesTreeView) // Focus back to main layout
+				}
 			}
 		}
 	})
 
 	return nil
+}
+
+func setDetailsText(uiState *UIState, text string) {
+	uiState.detailsRawText = text
+	uiState.detailsSearchTerm = ""
+	uiState.detailsSearchMatches = nil
+	uiState.detailsSearchIndex = 0
+	uiState.apiResourcesDetailsView.Highlight()
+	uiState.apiResourcesDetailsView.SetText(text)
+}
+
+func applyDetailsSearch(uiState *UIState, term string) {
+	uiState.detailsSearchTerm = term
+	uiState.detailsSearchMatches = findDetailsMatches(uiState.detailsRawText, term)
+	uiState.detailsSearchIndex = 0
+	renderDetailsText(uiState)
+}
+
+func clearDetailsSearch(uiState *UIState) {
+	if uiState.detailsSearchTerm == "" && len(uiState.detailsSearchMatches) == 0 {
+		return
+	}
+	uiState.detailsSearchTerm = ""
+	uiState.detailsSearchMatches = nil
+	uiState.detailsSearchIndex = 0
+	renderDetailsText(uiState)
+}
+
+func selectNextDetailsMatch(uiState *UIState) {
+	if len(uiState.detailsSearchMatches) == 0 {
+		return
+	}
+	uiState.detailsSearchIndex = (uiState.detailsSearchIndex + 1) % len(uiState.detailsSearchMatches)
+	renderDetailsText(uiState)
+}
+
+func selectPreviousDetailsMatch(uiState *UIState) {
+	if len(uiState.detailsSearchMatches) == 0 {
+		return
+	}
+	uiState.detailsSearchIndex--
+	if uiState.detailsSearchIndex < 0 {
+		uiState.detailsSearchIndex = len(uiState.detailsSearchMatches) - 1
+	}
+	renderDetailsText(uiState)
+}
+
+func renderDetailsText(uiState *UIState) {
+	if len(uiState.detailsSearchMatches) == 0 {
+		uiState.apiResourcesDetailsView.Highlight()
+		uiState.apiResourcesDetailsView.ScrollToBeginning()
+		uiState.apiResourcesDetailsView.SetText(uiState.detailsRawText)
+		return
+	}
+
+	currentMatch := uiState.detailsSearchMatches[uiState.detailsSearchIndex]
+	uiState.apiResourcesDetailsView.SetText(buildDetailsSearchText(
+		uiState.detailsRawText,
+		uiState.detailsSearchMatches,
+		uiState.detailsSearchIndex,
+	))
+	uiState.apiResourcesDetailsView.Highlight(currentMatch.regionID)
+	uiState.apiResourcesDetailsView.ScrollTo(detailsSearchScrollRow(uiState.detailsRawText, currentMatch), 0)
+}
+
+func buildDetailsSearchText(text string, matches []detailsMatch, currentIndex int) string {
+	var b strings.Builder
+	last := 0
+	for i, match := range matches {
+		b.WriteString(text[last:match.start])
+		b.WriteString(`["`)
+		b.WriteString(match.regionID)
+		b.WriteString(`"]`)
+		if i == currentIndex {
+			b.WriteString(detailsSearchCurrentMatchStyle)
+		} else {
+			b.WriteString(detailsSearchMatchStyle)
+		}
+		b.WriteString(text[match.start:match.end])
+		b.WriteString(detailsSearchResetStyle)
+		b.WriteString(`[""]`)
+		last = match.end
+	}
+	b.WriteString(text[last:])
+	return b.String()
+}
+
+func findDetailsMatches(text, term string) []detailsMatch {
+	term = strings.TrimSpace(term)
+	if term == "" {
+		return nil
+	}
+
+	lowerText := strings.ToLower(text)
+	lowerTerm := strings.ToLower(term)
+	var matches []detailsMatch
+	offset := 0
+
+	for {
+		idx := strings.Index(lowerText[offset:], lowerTerm)
+		if idx == -1 {
+			break
+		}
+		start := offset + idx
+		end := start + len(term)
+		matches = append(matches, detailsMatch{
+			start:    start,
+			end:      end,
+			regionID: fmt.Sprintf("details-%d", len(matches)),
+		})
+		offset = end
+	}
+
+	return matches
+}
+
+func detailsSearchScrollRow(text string, match detailsMatch) int {
+	row := strings.Count(text[:match.start], "\n") - 1
+	if row < 0 {
+		return 0
+	}
+	return row
 }
 
 func getClosestParentThatHasChildren(uiState *UIState, node *tview.TreeNode) *tview.TreeNode {
@@ -272,6 +479,9 @@ func setupListenersForApp(uiState *UIState) error {
 	uiState.app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		// search input
 		if event.Key() == tcell.KeyRune && event.Rune() == '/' {
+			if uiState.app.GetFocus() == uiState.apiResourcesDetailsView {
+				return event
+			}
 			if uiState.cmdInputIsOn {
 				return nil
 			}

--- a/internal/apidocs/uievents_test.go
+++ b/internal/apidocs/uievents_test.go
@@ -1,0 +1,52 @@
+package apidocs
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestFindDetailsMatches_CaseInsensitive(t *testing.T) {
+	got := findDetailsMatches("Binding binding BINDING", "binding")
+
+	want := []detailsMatch{
+		{start: 0, end: 7, regionID: "details-0"},
+		{start: 8, end: 15, regionID: "details-1"},
+		{start: 16, end: 23, regionID: "details-2"},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestFindDetailsMatches_EmptyTerm(t *testing.T) {
+	got := findDetailsMatches("Binding", "   ")
+	if got != nil {
+		t.Fatalf("expected nil matches, got %v", got)
+	}
+}
+
+func TestBuildDetailsSearchText_HighlightsCurrentDifferently(t *testing.T) {
+	text := "Binding binding"
+	matches := findDetailsMatches(text, "binding")
+
+	got := buildDetailsSearchText(text, matches, 1)
+
+	if !strings.Contains(got, `["details-0"]`+detailsSearchMatchStyle+`Binding`+detailsSearchResetStyle+`[""]`) {
+		t.Fatalf("expected non-current match styling in %q", got)
+	}
+
+	if !strings.Contains(got, `["details-1"]`+detailsSearchCurrentMatchStyle+`binding`+detailsSearchResetStyle+`[""]`) {
+		t.Fatalf("expected current match styling in %q", got)
+	}
+}
+
+func TestDetailsSearchScrollRow(t *testing.T) {
+	text := "events\n\nKIND:\nEvent\nVERSION:\nv1"
+	match := detailsMatch{start: strings.Index(text, "KIND"), end: strings.Index(text, "KIND") + len("KIND")}
+
+	if got := detailsSearchScrollRow(text, match); got != 1 {
+		t.Fatalf("expected scroll row 1, got %d", got)
+	}
+}

--- a/internal/apidocs/uisearch.go
+++ b/internal/apidocs/uisearch.go
@@ -21,6 +21,9 @@ func buildFilteredTree(node *tview.TreeNode, searchTerm string) *tview.TreeNode 
 	if strings.Contains(strings.ToLower(node.GetText()), searchTerm) && shouldHighlight {
 		matched = true
 	}
+	if matched && data.IsNodeType(nodeTypeResource) {
+		return cloneTreeForResourceMatch(node)
+	}
 
 	// Recursively process children
 	var matchingChildren []*tview.TreeNode
@@ -50,6 +53,38 @@ func buildFilteredTree(node *tview.TreeNode, searchTerm string) *tview.TreeNode 
 	return nil
 }
 
+func cloneTree(node *tview.TreeNode, expanded bool) *tview.TreeNode {
+	if node == nil {
+		return nil
+	}
+
+	newNode := tview.NewTreeNode(node.GetText()).
+		SetReference(node.GetReference()).
+		SetExpanded(expanded)
+
+	for _, child := range node.GetChildren() {
+		newNode.AddChild(cloneTree(child, expanded))
+	}
+
+	return newNode
+}
+
+func cloneTreeForResourceMatch(node *tview.TreeNode) *tview.TreeNode {
+	if node == nil {
+		return nil
+	}
+
+	newNode := tview.NewTreeNode(node.GetText()).
+		SetReference(node.GetReference()).
+		SetExpanded(false)
+
+	for _, child := range node.GetChildren() {
+		newNode.AddChild(cloneTree(child, false))
+	}
+
+	return newNode
+}
+
 func showFilteredTree(uiState *UIState, treeView *tview.TreeView, searchTerm string) {
 	if searchTerm == "" {
 		// Show full tree again
@@ -58,7 +93,8 @@ func showFilteredTree(uiState *UIState, treeView *tview.TreeView, searchTerm str
 		return
 	}
 
-	filteredRoot := buildFilteredTree(uiState.apiResourcesRootNode, strings.ToLower(searchTerm))
+	searchRoot := getSearchRoot(uiState, treeView)
+	filteredRoot := buildFilteredTree(searchRoot, strings.ToLower(searchTerm))
 	if filteredRoot == nil {
 		// Nothing matched -> empty root
 		filteredRoot = tview.NewTreeNode("(no matches)")
@@ -67,4 +103,15 @@ func showFilteredTree(uiState *UIState, treeView *tview.TreeView, searchTerm str
 	resetNodeColors(filteredRoot)
 	uiState.isInFilter = true
 	treeView.SetRoot(filteredRoot).SetCurrentNode(filteredRoot)
+}
+
+func getSearchRoot(uiState *UIState, treeView *tview.TreeView) *tview.TreeNode {
+	if treeView == nil {
+		return uiState.apiResourcesRootNode
+	}
+	root := treeView.GetRoot()
+	if root == nil {
+		return uiState.apiResourcesRootNode
+	}
+	return root
 }

--- a/internal/apidocs/uisearch_test.go
+++ b/internal/apidocs/uisearch_test.go
@@ -1,0 +1,108 @@
+package apidocs
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/rivo/tview"
+)
+
+func TestBuildFilteredTree_ResourceMatchKeepsFullSubtree(t *testing.T) {
+	root := tviewNode("API Resources >", &TreeData{nodeType: nodeTypeRoot})
+	group := tviewNode("apps/v1", &TreeData{nodeType: nodeTypeGroup})
+	resource := tviewNode("Deployment (deployments)", &TreeData{
+		nodeType: nodeTypeResource,
+		path:     "Deployment",
+	})
+	fieldA := tviewNode("metadata", &TreeData{nodeType: nodeTypeField, path: "Deployment.metadata"})
+	fieldB := tviewNode("spec", &TreeData{nodeType: nodeTypeField, path: "Deployment.spec"})
+
+	resource.AddChild(fieldA)
+	resource.AddChild(fieldB)
+	group.AddChild(resource)
+	root.AddChild(group)
+
+	filtered := buildFilteredTree(root, "deployment")
+	if filtered == nil {
+		t.Fatal("expected filtered tree")
+	}
+
+	filteredGroup := filtered.GetChildren()[0]
+	filteredResource := filteredGroup.GetChildren()[0]
+	if len(filteredResource.GetChildren()) != 2 {
+		t.Fatalf("expected full resource subtree, got %d children", len(filteredResource.GetChildren()))
+	}
+	if filteredResource.IsExpanded() {
+		t.Fatal("expected matched resource node to stay collapsed")
+	}
+	if filteredResource.GetChildren()[0].IsExpanded() {
+		t.Fatal("expected resource field subtree to stay collapsed")
+	}
+}
+
+func TestBuildFilteredTree_FieldMatchKeepsOnlyMatchingBranch(t *testing.T) {
+	root := tviewNode("API Resources >", &TreeData{nodeType: nodeTypeRoot})
+	group := tviewNode("apps/v1", &TreeData{nodeType: nodeTypeGroup})
+	resource := tviewNode("Deployment (deployments)", &TreeData{
+		nodeType: nodeTypeResource,
+		path:     "Deployment",
+	})
+	fieldA := tviewNode("metadata", &TreeData{nodeType: nodeTypeField, path: "Deployment.metadata"})
+	fieldB := tviewNode("spec", &TreeData{nodeType: nodeTypeField, path: "Deployment.spec"})
+
+	resource.AddChild(fieldA)
+	resource.AddChild(fieldB)
+	group.AddChild(resource)
+	root.AddChild(group)
+
+	filtered := buildFilteredTree(root, "metadata")
+	if filtered == nil {
+		t.Fatal("expected filtered tree")
+	}
+
+	filteredGroup := filtered.GetChildren()[0]
+	filteredResource := filteredGroup.GetChildren()[0]
+	if len(filteredResource.GetChildren()) != 1 {
+		t.Fatalf("expected only matching branch, got %d children", len(filteredResource.GetChildren()))
+	}
+	if filteredResource.GetChildren()[0].GetText() != "metadata" {
+		t.Fatalf("expected metadata branch, got %q", filteredResource.GetChildren()[0].GetText())
+	}
+}
+
+func TestGetSearchRoot_UsesCurrentTreeRoot(t *testing.T) {
+	globalRoot := tviewNode("API Resources >", &TreeData{nodeType: nodeTypeRoot})
+	group := tviewNode("apps/v1", &TreeData{nodeType: nodeTypeGroup})
+	resource := tviewNode("Deployment (deployments)", &TreeData{nodeType: nodeTypeResource, path: "Deployment"})
+	globalRoot.AddChild(group)
+	group.AddChild(resource)
+
+	treeView := tview.NewTreeView().SetRoot(resource)
+	uiState := &UIState{
+		apiResourcesRootNode: globalRoot,
+		apiResourcesTreeView: treeView,
+		explainCache:         &sync.Map{},
+	}
+
+	got := getSearchRoot(uiState, treeView)
+	if got != resource {
+		t.Fatalf("expected current tree root, got %q", got.GetText())
+	}
+}
+
+func TestGetSearchRoot_FallsBackToGlobalRoot(t *testing.T) {
+	globalRoot := tviewNode("API Resources >", &TreeData{nodeType: nodeTypeRoot})
+	uiState := &UIState{
+		apiResourcesRootNode: globalRoot,
+		explainCache:         &sync.Map{},
+	}
+
+	got := getSearchRoot(uiState, nil)
+	if got != globalRoot {
+		t.Fatal("expected fallback to global root")
+	}
+}
+
+func tviewNode(text string, data *TreeData) *tview.TreeNode {
+	return tview.NewTreeNode(text).SetReference(data)
+}


### PR DESCRIPTION
Closes #103

## Summary

This PR improves resource inspection and search UX in `kubectl apidocs`.

It adds recursive explain for selected resources, scopes tree search to the current visible context, and adds search support inside the details pane with next/previous match navigation.

## Testing

- `make test`